### PR TITLE
処理、メッセージ追加

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,8 @@ let status = false,
   dispatcher,
   songs;
 
+var timeout = null;
+
 client.on(`ready`, () => {
   console.log(`ログインが完了しました。`);
 });
@@ -73,7 +75,13 @@ global.quiz = async (msg, split) => {
     if (msg.member.voiceChannel) {
       if (!split[2]) return msg.channel.send(`再生リストIDを入力してください`);
       msg.channel.send(`再生リスト読み込み中...`);
+      if(split[2].length < 34) { return msg.channel.send(":x: 文字数が足りません(34文字以上であることが必須です)。"); }
       split[2] = split[2].replace("https://www.youtube.com/playlist?list=", "");
+      if (~split[2].indexOf("https://www.youtube.com/watch?v=") && ~split[2].indexOf("&list=")) {
+        split[2] = split[2].replace("https://www.youtube.com/watch?v=", "").slice(11);
+        if (~split[2].indexOf("&index=")) { split[2] = split[2].replace("&index=", "").slice(1); }
+        split[2] = split[2].replace("&list=", "");
+      }
       const list = await ypi(env.APIKEY, split[2]).
         catch((error) => msg.channel.send(`再生リスト読み込みエラー：${error}`));
       songs = list.map((video) => [video.resourceId.videoId, video.title]);
@@ -97,6 +105,7 @@ global.quiz = async (msg, split) => {
   }
   if (split[1] === `end` || split[1] === `stop`) {
     if (status) {
+      client.clearTimeout(timeout);
       status = false;
       correct = false;
       dispatcher.end();
@@ -111,7 +120,7 @@ global.quiz = async (msg, split) => {
 function nextquiz(msg, number = 0) {
   msg.channel.send(`${++number} 問目！五秒後に始まるよ！`);
   correct = false;
-  setTimeout(() => {
+  timeout = client.setTimeout(() => {
     msg.channel.send(`スタート！この曲は何でしょう？音楽の再生が終了するまで誰も答えられなかった場合は、誰にもポイントは入りません。`);
     songinfo = songs[Math.floor(Math.random() * songs.length)];
     console.log(songinfo);


### PR DESCRIPTION
 - quiz end したときが曲スタート前の場合に、終了した**後で**「音楽の再生が終了しました！・・・」になるのを修正(？)
 - quiz start <ID>のところを、前はURLでできるように強化したけど、さらに強化。
   - 以前：``https://www.youtube.com/playlist?list=PLRBp0Fe2GpgnIh0AiYKh7o7HnYAej-5ph``__だけ__。
   - 今回から：``https://www.youtube.com/watch?v=sJgOjtxsuZs&index=5&list=PLRBp0Fe2GpgnIh0AiYKh7o7HnYAej-5ph``もOK！
 - 34文字(プレイリストIDの文字数)未満の時にエラーが発生するように処理を追加。
 - ✔️ 動作テスト済み。