### PR TITLE
バグ修正

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,12 +78,12 @@ global.quiz = async (msg, split) => {
       if(split[2].length < 34) { return msg.channel.send(":x: 文字数が足りません(34文字以上であることが必須です)。"); }
       split[2] = split[2].replace("https://www.youtube.com/playlist?list=", "");
       if (~split[2].indexOf("https://www.youtube.com/watch?v=") && ~split[2].indexOf("&list=")) {
-        split[2] = split[2].replace("https://www.youtube.com/watch?v=", "").slice(11);
-        if (~split[2].indexOf("&index=")) { split[2] = split[2].replace("&index=", "").slice(1); }
         split[2] = split[2].replace("&list=", "");
+        split[2] = split[2].replace("https://www.youtube.com/watch?v=", "").slice(11);
+        split[2] = split[2].replace(/&index=(\\.|[^&])*/gm, "");
       }
       const list = await ypi(env.APIKEY, split[2]).
-        catch((error) => msg.channel.send(`再生リスト読み込みエラー：${error}`));
+        catch((error) => msg.channel.send(`再生リスト読み込みエラー：\`${error}\` (\`${split[2]})\``));
       songs = list.map((video) => [video.resourceId.videoId, video.title]);
       msg.member.voiceChannel.join().then((con) => {
         connection = con;


### PR DESCRIPTION
・YouTubeのリンクで``&index=``が0～9でないとエラーになるのを修正。
・再生リストの読み込み失敗の時にプレイリストID(split[2])を表示。
・ ✅  安定の動作確認済み

このコードでエラー確認(今回の作業範囲ではないから原因はわからない)。
https://pastebin.com/qAx0PujT