### PR TITLE
答えの判定を改善

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,11 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.12.0
+# patches apply the minimum changes required to fix a vulnerability
+patch:
+  'npm:tough-cookie:20160722':
+    - youtube-playlist-info > youtube-api > googleapis > request > tough-cookie:
+        patched: '2018-06-02T15:15:44.063Z'
+  'npm:tough-cookie:20170905':
+    - youtube-playlist-info > youtube-api > googleapis > request > tough-cookie:
+        patched: '2018-06-02T15:15:44.063Z'
+ignore: {}

--- a/index.js
+++ b/index.js
@@ -30,7 +30,14 @@ client.on(`message`, async (msg) => {
       msg.channel.send(":x: そのようなコマンドはありません。");
     }
   } else if (status) {
-    if (~songinfo[1].split(/\s+/).indexOf(msg.content)) {
+    let a = songinfo[1].replace("「", "").replace(/」[^]*/gm, "");
+    a = a.replace(/[^]*(\\.|[^- ])*- /gm, "");
+    a = a.replace(/[^]*(\\.|[^／])／/gm, "");
+    a = a.replace(/[^]*(\\.|[^「])「/gm, "").replace("」", "");
+    a = a.replace(/\(.*/gm, "");
+    a = a.replace(/（.*/gm, "");
+    // if (~songinfo[1].split(/\s+/).indexOf(msg.content)) {
+    if (~songinfo[1].indexOf(a)) {
       correct = true;
       msg.channel.send(`正解！答えは「${songinfo[1]}」でした！\nYouTube: https://youtu.be/${songinfo[0]}`);
       dispatcher.end();
@@ -83,7 +90,15 @@ global.quiz = async (msg, split) => {
         split[2] = split[2].replace(/&index=(\\.|[^&])*/gm, "");
       }
       const list = await ypi(env.APIKEY, split[2]).
-        catch((error) => msg.channel.send(`再生リスト読み込みエラー：\`${error}\` (\`${split[2]})\``));
+        catch((error) => {
+	  if (error == "Error: The request is not properly authorized to retrieve the specified playlist.") {
+	      msg.channel.send(":x: このプレイリストは非公開です。");
+	      return;
+	  } else {
+	    msg.channel.send(`再生リスト読み込みエラー：\`${error}\``);
+	    return;
+	  }
+	});
       songs = list.map((video) => [video.resourceId.videoId, video.title]);
       msg.member.voiceChannel.join().then((con) => {
         connection = con;

--- a/index.js
+++ b/index.js
@@ -92,11 +92,13 @@ global.quiz = async (msg, split) => {
       const list = await ypi(env.APIKEY, split[2]).
         catch((error) => {
 	  if (error == "Error: The request is not properly authorized to retrieve the specified playlist.") {
-	      msg.channel.send(":x: このプレイリストは非公開です。");
-	      return;
+	    return msg.channel.send(":x: このプレイリストは非公開です。");
+	  } else if (error == "Error: The playlist identified with the requests <code>playlistId</code> parameter cannot be found.") {
+	    return msg.channel.send(":x: このプレイリストは存在しません。");
+	  } else if (error == "Error: Bad Request") {
+	    return msg.channel.send(":x: Bad Request: YouTube Data APIキーが間違っている可能性があります。");
 	  } else {
-	    msg.channel.send(`再生リスト読み込みエラー：\`${error}\``);
-	    return;
+	    return msg.channel.send(`再生リスト読み込みエラー：\`${error}\``);
 	  }
 	});
       songs = list.map((video) => [video.resourceId.videoId, video.title]);


### PR DESCRIPTION
- .snykは気にしない
- いちいちreplaceして曲名を削って、答えを創造する。
- プレイリストの読み込み時のエラーメッセージを追加。
- 前あった、`~songinfo[1].split(...)...`は消えました。ちゃんと動いてくれないから。
- ✅ 動作テスト済み。曲名(答え)のテストも完了。